### PR TITLE
remove typo in a sourcemap

### DIFF
--- a/resources/ignore-list-wrong-type-3.js.map
+++ b/resources/ignore-list-wrong-type-3.js.map
@@ -4,5 +4,5 @@
   "sourcesContent": [""],
   "mappings": "",
   "names": [],
-  "ignoreList": 0;
+  "ignoreList": 0
 }


### PR DESCRIPTION
I noticed this change was missing from the tc39 version of the repo so adding it here.