### PR TITLE
Add more test coverage to cover remaining cases

### DIFF
--- a/resources/file-not-a-string-1.js
+++ b/resources/file-not-a-string-1.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=file-not-a-string-1.js.map

--- a/resources/file-not-a-string-1.js.map
+++ b/resources/file-not-a-string-1.js.map
@@ -1,0 +1,8 @@
+{
+  "version" : 3,
+  "file": [],
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "names": [],
+  "mappings": ""
+}

--- a/resources/file-not-a-string-2.js
+++ b/resources/file-not-a-string-2.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=file-not-a-string-2.js.map

--- a/resources/file-not-a-string-2.js.map
+++ b/resources/file-not-a-string-2.js.map
@@ -1,0 +1,8 @@
+{
+  "version" : 3,
+  "file": 235324,
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "names": [],
+  "mappings": ""
+}

--- a/resources/index-map-empty-sections.js
+++ b/resources/index-map-empty-sections.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=index-map-empty-sections.js.map

--- a/resources/index-map-empty-sections.js.map
+++ b/resources/index-map-empty-sections.js.map
@@ -1,0 +1,4 @@
+{
+  "version": 3,
+  "sections": []
+}

--- a/resources/index-map-file-wrong-type-1.js
+++ b/resources/index-map-file-wrong-type-1.js
@@ -1,0 +1,2 @@
+function foo(){return 42}function bar(){return 24}foo();bar();
+//# sourceMappingURL=index-map-file-wrong-type-1.js.map

--- a/resources/index-map-file-wrong-type-1.js.map
+++ b/resources/index-map-file-wrong-type-1.js.map
@@ -1,6 +1,6 @@
 {
   "version": 3,
-  "file": "basic-mapping-as-index-map.js",
+  "file": [],
   "sections": [
     {
       "offset": { "line": 0, "column": 0 },

--- a/resources/index-map-file-wrong-type-2.js
+++ b/resources/index-map-file-wrong-type-2.js
@@ -1,0 +1,2 @@
+function foo(){return 42}function bar(){return 24}foo();bar();
+//# sourceMappingURL=index-map-file-wrong-type-2.js.map

--- a/resources/index-map-file-wrong-type-2.js.map
+++ b/resources/index-map-file-wrong-type-2.js.map
@@ -1,6 +1,6 @@
 {
   "version": 3,
-  "file": "basic-mapping-as-index-map.js",
+  "file": 2345234234,
   "sections": [
     {
       "offset": { "line": 0, "column": 0 },

--- a/resources/index-map-invalid-sub-map.js
+++ b/resources/index-map-invalid-sub-map.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=index-map-invalid-sub-map.js.map

--- a/resources/index-map-invalid-sub-map.js.map
+++ b/resources/index-map-invalid-sub-map.js.map
@@ -1,0 +1,13 @@
+{
+  "version": 3,
+  "file": "index-map-invalid-sub-map.js",
+  "sections": [
+    {
+      "offset": { "line": 0, "column": 0 },
+      "map": {
+        "version": "3",
+        "mappings": 7
+      }
+    }
+  ]
+}

--- a/resources/index-map-missing-file.js
+++ b/resources/index-map-missing-file.js
@@ -1,0 +1,2 @@
+function foo(){return 42}function bar(){return 24}foo();bar();
+//# sourceMappingURL=index-map-missing-file.js.map

--- a/resources/index-map-missing-file.js.map
+++ b/resources/index-map-missing-file.js.map
@@ -1,6 +1,5 @@
 {
   "version": 3,
-  "file": "basic-mapping-as-index-map.js",
   "sections": [
     {
       "offset": { "line": 0, "column": 0 },

--- a/resources/index-map-two-concatenated-sources.js.map
+++ b/resources/index-map-two-concatenated-sources.js.map
@@ -1,5 +1,6 @@
 {
   "version": 3,
+  "file": "index-map-two-concatenated-sources.js",
   "sections": [
     {
       "offset": { "line": 0, "column": 0 },

--- a/resources/mapping-semantics-column-reset.js
+++ b/resources/mapping-semantics-column-reset.js
@@ -1,0 +1,3 @@
+ foo
+ bar
+//# sourceMappingURL=mapping-semantics-column-reset.js.map

--- a/resources/mapping-semantics-column-reset.js.map
+++ b/resources/mapping-semantics-column-reset.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": ["mapping-semantics-column-reset-original.js"],
+  "sourcesContent": ["foo\nbar"],
+  "mappings": "CAAA;CACA"
+}

--- a/resources/mapping-semantics-five-field-segment.js
+++ b/resources/mapping-semantics-five-field-segment.js
@@ -1,0 +1,2 @@
+foo
+//# sourceMappingURL=mapping-semantics-five-field-segment.js.map

--- a/resources/mapping-semantics-five-field-segment.js.map
+++ b/resources/mapping-semantics-five-field-segment.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "names": ["foo"],
+  "sources": ["unused", "mapping-semantics-five-field-segment-original.js"],
+  "sourcesContent": ["", "\n\n  foo"],
+  "mappings": "CCEEA"
+}

--- a/resources/mapping-semantics-four-field-segment.js
+++ b/resources/mapping-semantics-four-field-segment.js
@@ -1,0 +1,2 @@
+foo
+//# sourceMappingURL=mapping-semantics-four-field-segment.js.map

--- a/resources/mapping-semantics-four-field-segment.js.map
+++ b/resources/mapping-semantics-four-field-segment.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": ["unused", "mapping-semantics-four-field-segment-original.js"],
+  "sourcesContent": ["", "\n\n  foo"],
+  "mappings": "CCEE"
+}

--- a/resources/mapping-semantics-relative-1.js
+++ b/resources/mapping-semantics-relative-1.js
@@ -1,0 +1,2 @@
+ foo bar
+//# sourceMappingURL=mapping-semantics-relative-1.js.map

--- a/resources/mapping-semantics-relative-1.js.map
+++ b/resources/mapping-semantics-relative-1.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "names": ["foo", "bar"],
+  "sources": ["unused", "mapping-semantics-relative-1-original.js"],
+  "sourcesContent": ["", "foo bar"],
+  "mappings": "CCAA,IAAI"
+}

--- a/resources/mapping-semantics-relative-2.js
+++ b/resources/mapping-semantics-relative-2.js
@@ -1,0 +1,3 @@
+ foo
+  bar
+//# sourceMappingURL=mapping-semantics-relative-2.js.map

--- a/resources/mapping-semantics-relative-2.js.map
+++ b/resources/mapping-semantics-relative-2.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "names": ["foo", "bar"],
+  "sources": ["unused", "mapping-semantics-relative-2-original.js"],
+  "sourcesContent": ["", "  foo\n  bar"],
+  "mappings": "CCAEA;EACAC"
+}

--- a/resources/mapping-semantics-single-field-segment.js
+++ b/resources/mapping-semantics-single-field-segment.js
@@ -1,0 +1,2 @@
+ 3
+//# sourceMappingURL=mapping-semantics-single-field-segment.js.map

--- a/resources/mapping-semantics-single-field-segment.js.map
+++ b/resources/mapping-semantics-single-field-segment.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": ["mapping-semantics-single-field-segment-original.js"],
+  "sourcesContent": ["3 3"],
+  "mappings": "AAAC,E"
+}

--- a/resources/source-resolution-absolute-url.js
+++ b/resources/source-resolution-absolute-url.js
@@ -1,0 +1,2 @@
+function foo(){return 42}function bar(){return 24}foo();bar();
+//# sourceMappingURL=source-resolution-absolute-url.js.map

--- a/resources/source-resolution-absolute-url.js.map
+++ b/resources/source-resolution-absolute-url.js.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "file": "source-root-resolution.js",
+  "names": ["foo", "bar"],
+  "sources": ["/baz/quux/basic-mapping-original.js"],
+  "sourcesContent": ["function foo() {\nreturn 42;\n }\n function bar() {\n return 24;\n }\n foo();\n bar();"],
+  "mappings": "AAAA,SAASA"
+}

--- a/resources/source-root-not-a-string-1.js
+++ b/resources/source-root-not-a-string-1.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=source-root-not-a-string-1.js.map

--- a/resources/source-root-not-a-string-1.js.map
+++ b/resources/source-root-not-a-string-1.js.map
@@ -1,0 +1,8 @@
+{
+  "version" : 3,
+  "sourceRoot": [],
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "names": [],
+  "mappings": ""
+}

--- a/resources/source-root-not-a-string-2.js
+++ b/resources/source-root-not-a-string-2.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=source-root-not-a-string-1.js.map

--- a/resources/source-root-not-a-string-2.js.map
+++ b/resources/source-root-not-a-string-2.js.map
@@ -1,0 +1,8 @@
+{
+  "version" : 3,
+  "sourceRoot": -10923409,
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "names": [],
+  "mappings": ""
+}

--- a/resources/source-root-resolution.js
+++ b/resources/source-root-resolution.js
@@ -1,0 +1,2 @@
+function foo(){return 42}function bar(){return 24}foo();bar();
+//# sourceMappingURL=source-root-resolution.js.map

--- a/resources/source-root-resolution.js.map
+++ b/resources/source-root-resolution.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "sourceRoot": "theroot",
+  "file": "source-root-resolution.js",
+  "names": ["foo", "bar"],
+  "sources": ["basic-mapping-original.js"],
+  "sourcesContent": "function foo() {\n return 42;\n }\n function bar() {\n return 24;\n }\n foo();\n bar();",
+  "mappings": "AAAA,SAASA"
+}

--- a/resources/valid-mapping-empty-string.js
+++ b/resources/valid-mapping-empty-string.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=valid-mapping-empty-string.js.map

--- a/resources/valid-mapping-empty-string.js.map
+++ b/resources/valid-mapping-empty-string.js.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "valid-mapping-empty-string.js",
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "mappings": ""
+}

--- a/resources/vlq-valid-continuation-bit-present-1.js
+++ b/resources/vlq-valid-continuation-bit-present-1.js
@@ -1,0 +1,2 @@
+               3
+//# sourceMappingURL=vlq-valid-continuation-bit-present-1.js.map

--- a/resources/vlq-valid-continuation-bit-present-1.js.map
+++ b/resources/vlq-valid-continuation-bit-present-1.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": ["vlq-valid-continuation-bit-present-1-original.js"],
+  "sourcesContent": [" 3"],
+  "mappings": "+gAgAgAigA"
+}

--- a/resources/vlq-valid-continuation-bit-present-2.js
+++ b/resources/vlq-valid-continuation-bit-present-2.js
@@ -1,0 +1,4 @@
+
+
+                3
+//# sourceMappingURL=vlq-valid-continuation-bit-present-2.js.map

--- a/resources/vlq-valid-continuation-bit-present-2.js.map
+++ b/resources/vlq-valid-continuation-bit-present-2.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": ["vlq-valid-continuation-bit-present-2-original.js"],
+  "sourcesContent": ["\n 3"],
+  "mappings": ";;gBACC"
+}

--- a/resources/vlq-valid-negative-digit.js
+++ b/resources/vlq-valid-negative-digit.js
@@ -1,0 +1,4 @@
+
+
+  4            3
+//# sourceMappingURL=vlq-valid-single-digit.js.map

--- a/resources/vlq-valid-negative-digit.js.map
+++ b/resources/vlq-valid-negative-digit.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": ["vlq-valid-negative-digit-original.js"],
+  "sourcesContent": ["\n 43"],
+  "mappings": ";;eACE,bAAD"
+}

--- a/resources/vlq-valid-single-digit.js
+++ b/resources/vlq-valid-single-digit.js
@@ -1,0 +1,2 @@
+               3
+//# sourceMappingURL=vlq-valid-single-digit.js.map

--- a/resources/vlq-valid-single-digit.js.map
+++ b/resources/vlq-valid-single-digit.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": ["vlq-valid-single-digit-original.js"],
+  "sourcesContent": ["3"],
+  "mappings": "eAAA"
+}

--- a/source-map-spec-tests.json
+++ b/source-map-spec-tests.json
@@ -78,6 +78,34 @@
       "sourceMapIsValid": true
     },
     {
+      "name": "fileNotAString1",
+      "description": "Test a source map with a file field that is not a valid string",
+      "baseFile": "file-not-a-string-1.js",
+      "sourceMapFile": "file-not-a-string-1.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "fileNotAString2",
+      "description": "Test a source map with a file field that is not a valid string",
+      "baseFile": "file-not-a-string-2.js",
+      "sourceMapFile": "file-not-a-string-2.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "sourceRootNotAString1",
+      "description": "Test a source map with a sourceRoot field that is not a valid string",
+      "baseFile": "source-root-not-a-string-1.js",
+      "sourceMapFile": "source-root-not-a-string-1.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "sourceRootNotAString2",
+      "description": "Test a source map with a sourceRoot field that is not a valid string",
+      "baseFile": "source-root-not-a-string-2.js",
+      "sourceMapFile": "source-root-not-a-string-2.js.map",
+      "sourceMapIsValid": false
+    },
+    {
       "name": "namesMissing",
       "description": "Test a source map that is missing a necessary names field",
       "baseFile": "names-missing.js",
@@ -357,6 +385,13 @@
       "sourceMapIsValid": true
     },
     {
+      "name": "validMappingEmptyString",
+      "description": "Test a source map with an empty string mapping",
+      "baseFile": "valid-mapping-empty-string.js",
+      "sourceMapFile": "valid-mapping-empty-string.js.map",
+      "sourceMapIsValid": true
+    },
+    {
       "name": "indexMapWrongTypeSections",
       "description": "Test an index map with a sections field with the wrong type",
       "baseFile": "index-map-wrong-type-sections.js",
@@ -406,6 +441,13 @@
       "sourceMapIsValid": false
     },
     {
+      "name": "indexMapInvalidSubMap",
+      "description": "Test that an index map that has an invalid section map",
+      "baseFile": "index-map-invalid-sub-map.js",
+      "sourceMapFile": "index-map-invalid-sub-map.js.map",
+      "sourceMapIsValid": false
+    },
+    {
       "name": "indexMapMissingOffset",
       "description": "Test that an index map that is missing a section offset",
       "baseFile": "index-map-missing-offset.js",
@@ -438,6 +480,27 @@
       "description": "Test that an index map that has an offset column field with the wrong type of value",
       "baseFile": "index-map-offset-column-wrong-type.js",
       "sourceMapFile": "index-map-offset-column-wrong-type.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "indexMapEmptySections",
+      "description": "Test a trivial index map with no sections",
+      "baseFile": "index-map-empty-sections.js",
+      "sourceMapFile": "index-map-empty-sections.js.map",
+      "sourceMapIsValid": true
+    },
+    {
+      "name": "indexMapFileWrongType1",
+      "description": "Test an index map with a file field with the wrong type",
+      "baseFile": "index-map-file-wrong-type-1.js",
+      "sourceMapFile": "index-map-file-wrong-type-1.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "indexMapFileWrongType2",
+      "description": "Test an index map with a file field with the wrong type",
+      "baseFile": "index-map-file-wrong-type-2.js",
+      "sourceMapFile": "index-map-file-wrong-type-2.js.map",
       "sourceMapIsValid": false
     },
     {
@@ -558,10 +621,181 @@
       ]
     },
     {
+      "name": "sourceRootResolution",
+      "description": "Similar to basic mapping test, but test resoultion of sources with a sourceRoot field",
+      "baseFile": "source-root-resolution.js",
+      "sourceMapFile": "source-root-resolution.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 0,
+          "originalSource": "theroot/basic-mapping-original.js",
+          "originalLine": 0,
+          "originalColumn": 0,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 9,
+          "originalSource": "theroot/basic-mapping-original.js",
+          "originalLine": 0,
+          "originalColumn": 9,
+          "mappedName": "foo"
+        }
+      ]
+    },
+    {
+      "name": "sourceResolutionAbsoluteURL",
+      "description": "Test resoultion of sources with absolute URLs",
+      "baseFile": "source-resolution-absolute-url.js",
+      "sourceMapFile": "source-resolution-absolute-url.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 0,
+          "originalSource": "/baz/quux/basic-mapping-original.js",
+          "originalLine": 0,
+          "originalColumn": 0,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 9,
+          "originalSource": "/baz/quux/basic-mapping-original.js",
+          "originalLine": 0,
+          "originalColumn": 9,
+          "mappedName": "foo"
+        }
+      ]
+    },
+    {
       "name": "basicMappingWithIndexMap",
       "description": "Test a version of basic-mapping.js.map that is split into sections with an index map",
       "baseFile": "basic-mapping-as-index-map.js",
       "sourceMapFile": "basic-mapping-as-index-map.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 0,
+          "originalSource": "basic-mapping-original.js",
+          "originalLine": 0,
+          "originalColumn": 0,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 9,
+          "originalSource": "basic-mapping-original.js",
+          "originalLine": 0,
+          "originalColumn": 9,
+          "mappedName": "foo"
+        },
+        {
+          "actionType": "checkMapping",
+          "originalSource": "basic-mapping-original.js",
+          "generatedLine": 0,
+          "generatedColumn": 15,
+          "originalLine": 1,
+          "originalColumn": 2,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "originalSource": "basic-mapping-original.js",
+          "generatedLine": 0,
+          "generatedColumn": 22,
+          "originalLine": 1,
+          "originalColumn": 9,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "originalSource": "basic-mapping-original.js",
+          "generatedLine": 0,
+          "generatedColumn": 24,
+          "originalLine": 2,
+          "originalColumn": 0,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "originalSource": "basic-mapping-original.js",
+          "generatedLine": 0,
+          "generatedColumn": 25,
+          "originalLine": 3,
+          "originalColumn": 0,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 34,
+          "originalSource": "basic-mapping-original.js",
+          "originalLine": 3,
+          "originalColumn": 9,
+          "mappedName": "bar"
+        },
+        {
+          "actionType": "checkMapping",
+          "originalSource": "basic-mapping-original.js",
+          "generatedLine": 0,
+          "generatedColumn": 40,
+          "originalLine": 4,
+          "originalColumn": 2,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "originalSource": "basic-mapping-original.js",
+          "generatedLine": 0,
+          "generatedColumn": 47,
+          "originalLine": 4,
+          "originalColumn": 9,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "originalSource": "basic-mapping-original.js",
+          "generatedLine": 0,
+          "generatedColumn": 49,
+          "originalLine": 5,
+          "originalColumn": 0,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "originalSource": "basic-mapping-original.js",
+          "generatedLine": 0,
+          "generatedColumn": 50,
+          "originalLine": 6,
+          "originalColumn": 0,
+          "mappedName": "foo"
+        },
+        {
+          "actionType": "checkMapping",
+          "originalSource": "basic-mapping-original.js",
+          "generatedLine": 0,
+          "generatedColumn": 56,
+          "originalLine": 7,
+          "originalColumn": 0,
+          "mappedName": "bar"
+        }
+      ]
+    },
+    {
+      "name": "indexMapWithMissingFile",
+      "description": "Same as the basic mapping index map test but without the optional file field",
+      "baseFile": "index-map-missing-file.js",
+      "sourceMapFile": "index-map-missing-file.js.map",
       "sourceMapIsValid": true,
       "testActions": [
         {
@@ -1074,6 +1308,231 @@
           "originalLine": 4,
           "originalColumn": 4,
           "mappedName": null
+        }
+      ]
+    },
+    {
+      "name": "vlqValidSingleDigit",
+      "description": "Test VLQ decoding for a single digit, no continuation VLQ",
+      "baseFile": "vlq-valid-single-digit.js",
+      "sourceMapFile": "vlq-valid-single-digit.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 15,
+          "originalSource": "vlq-valid-single-digit-original.js",
+          "originalLine": 0,
+          "originalColumn": 0,
+          "mappedName": null
+        }
+      ]
+    },
+    {
+      "name": "vlqValidNegativeDigit",
+      "description": "Test VLQ decoding where there's a negative digit, no continuation bit",
+      "baseFile": "vlq-valid-negative-digit.js",
+      "sourceMapFile": "vlq-valid-negative-digit.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 2,
+          "generatedColumn": 15,
+          "originalSource": "vlq-valid-negative-digit-original.js",
+          "originalLine": 1,
+          "originalColumn": 2,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 2,
+          "generatedColumn": 2,
+          "originalSource": "vlq-valid-negative-digit-original.js",
+          "originalLine": 1,
+          "originalColumn": 1,
+          "mappedName": null
+        }
+      ]
+    },
+    {
+      "name": "vlqValidContinuationBitPresent1",
+      "description": "Test VLQ decoding where continuation bits are present (continuations are leading zero)",
+      "baseFile": "vlq-valid-continuation-bit-present-1.js",
+      "sourceMapFile": "vlq-valid-continuation-bit-present-1.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 15,
+          "originalSource": "vlq-valid-continuation-bit-present-1-original.js",
+          "originalLine": 0,
+          "originalColumn": 1,
+          "mappedName": null
+        }
+      ]
+    },
+    {
+      "name": "vlqValidContinuationBitPresent2",
+      "description": "Test VLQ decoding where continuation bits are present (continuations have non-zero bits)",
+      "baseFile": "vlq-valid-continuation-bit-present-2.js",
+      "sourceMapFile": "vlq-valid-continuation-bit-present-2.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 2,
+          "generatedColumn": 16,
+          "originalSource": "vlq-valid-continuation-bit-present-2-original.js",
+          "originalLine": 1,
+          "originalColumn": 1,
+          "mappedName": null
+        }
+      ]
+    },
+    {
+      "name": "mappingSemanticsSingleFieldSegment",
+      "description": "Test mapping semantics for a single field segment mapping",
+      "baseFile": "mapping-semantics-single-field-segment.js",
+      "sourceMapFile": "mapping-semantics-single-field-segment.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 0,
+          "originalSource": "mapping-semantics-single-field-segment-original.js",
+          "originalLine": 0,
+          "originalColumn": 1,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 2,
+          "originalSource": null,
+          "originalLine": null,
+          "originalColumn": null,
+          "mappedName": null
+        }
+      ]
+    },
+    {
+      "name": "mappingSemanticsFourFieldSegment",
+      "description": "Test mapping semantics for a four field segment mapping",
+      "baseFile": "mapping-semantics-four-field-segment.js",
+      "sourceMapFile": "mapping-semantics-four-field-segment.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 1,
+          "originalSource": "mapping-semantics-four-field-segment-original.js",
+          "originalLine": 2,
+          "originalColumn": 2,
+          "mappedName": null
+        }
+      ]
+    },
+    {
+      "name": "mappingSemanticsFiveFieldSegment",
+      "description": "Test mapping semantics for a five field segment mapping",
+      "baseFile": "mapping-semantics-five-field-segment.js",
+      "sourceMapFile": "mapping-semantics-five-field-segment.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 1,
+          "originalSource": "mapping-semantics-five-field-segment-original.js",
+          "originalLine": 2,
+          "originalColumn": 2,
+          "mappedName": "foo"
+        }
+      ]
+    },
+    {
+      "name": "mappingSemanticsColumnReset",
+      "description": "Test that the generated column field resets to zero on new lines",
+      "baseFile": "mapping-semantics-column-reset.js",
+      "sourceMapFile": "mapping-semantics-column-reset.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 1,
+          "originalSource": "mapping-semantics-column-reset-original.js",
+          "originalLine": 0,
+          "originalColumn": 0,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 1,
+          "generatedColumn": 1,
+          "originalSource": "mapping-semantics-column-reset-original.js",
+          "originalLine": 1,
+          "originalColumn": 0,
+          "mappedName": null
+        }
+      ]
+    },
+    {
+      "name": "mappingSemanticsRelative1",
+      "description": "Test that fields are calculated relative to previous ones",
+      "baseFile": "mapping-semantics-relative-1.js",
+      "sourceMapFile": "mapping-semantics-relative-1.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 1,
+          "originalSource": "mapping-semantics-relative-1-original.js",
+          "originalLine": 0,
+          "originalColumn": 0,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 5,
+          "originalSource": "mapping-semantics-relative-1-original.js",
+          "originalLine": 0,
+          "originalColumn": 4,
+          "mappedName": null
+        }
+      ]
+    },
+    {
+      "name": "mappingSemanticsRelative2",
+      "description": "Test that fields are calculated relative to previous ones, across lines",
+      "baseFile": "mapping-semantics-relative-2.js",
+      "sourceMapFile": "mapping-semantics-relative-2.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 1,
+          "originalSource": "mapping-semantics-relative-2-original.js",
+          "originalLine": 0,
+          "originalColumn": 2,
+          "mappedName": "foo"
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 1,
+          "generatedColumn": 2,
+          "originalSource": "mapping-semantics-relative-2-original.js",
+          "originalLine": 1,
+          "originalColumn": 2,
+          "mappedName": "bar"
         }
       ]
     }


### PR DESCRIPTION
  * Add more tests for VLQ parsing
  * Add type correctness tests for remaining fields
  * Add more index map tests
  * Add tests related to source resolution
  * Add more tests for mapping semantics

Some cases that are still missing:

  * Tests for Wasm, CSS, etc. sources
  * Tests for relative URL resolution (it wasn't clear how best to integrate into test harnesses)