### PR TITLE
Add test for invalid padding character

### DIFF
--- a/resources/invalid-vlq-non-base64-char-padding.js
+++ b/resources/invalid-vlq-non-base64-char-padding.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=invalid-vlq-non-base64-char-padding.js.map

--- a/resources/invalid-vlq-non-base64-char-padding.js.map
+++ b/resources/invalid-vlq-non-base64-char-padding.js.map
@@ -1,0 +1,7 @@
+{
+  "version" : 3,
+  "sources": ["foo.js"],
+  "sourcesContent": ["hello world"],
+  "names": [],
+  "mappings": ";;A="
+}

--- a/source-map-spec-tests.json
+++ b/source-map-spec-tests.json
@@ -210,6 +210,13 @@
       "sourceMapIsValid": false
     },
     {
+      "name": "invalidVLQDueToNonBase64CharacterPadding",
+      "description": "Test a source map that has a mapping with an invalid padding character =",
+      "baseFile": "invalid-vlq-non-base64-char-padding.js",
+      "sourceMapFile": "invalid-vlq-non-base64-char-padding.js.map",
+      "sourceMapIsValid": false
+    },
+    {
       "name": "invalidVLQDueToMissingContinuationDigits",
       "description": "Test a source map that has a mapping with an invalid VLQ that has a continuation bit but no continuing digits",
       "baseFile": "invalid-vlq-missing-continuation.js",


### PR DESCRIPTION
Adds a new test to ensure the base64 padding character `=` is considered invalid