### PR TITLE
Add missing sourcesContent & mappings test cases

### DIFF
--- a/resources/mappings-missing.js
+++ b/resources/mappings-missing.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=mappings-missing.js.map

--- a/resources/mappings-missing.js.map
+++ b/resources/mappings-missing.js.map
@@ -1,0 +1,6 @@
+{
+  "version" : 3,
+  "names": ["foo"],
+  "sources": ["1.js"],
+  "sourcesContent": ["hello world"]
+}

--- a/resources/sources-content-missing.js
+++ b/resources/sources-content-missing.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=sources-content-missing.js.map

--- a/resources/sources-content-missing.js.map
+++ b/resources/sources-content-missing.js.map
@@ -1,0 +1,6 @@
+{
+  "version" : 3,
+  "names": ["foo"],
+  "sources": ["basic-mapping-original.js"],
+  "mappings": ""
+}

--- a/resources/sources-content-not-a-list-1.js
+++ b/resources/sources-content-not-a-list-1.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=sources-content-not-a-list-1.js.map

--- a/resources/sources-content-not-a-list-1.js.map
+++ b/resources/sources-content-not-a-list-1.js.map
@@ -1,0 +1,7 @@
+{
+  "version" : 3,
+  "sources": ["first.js"],
+  "sourcesContent": "not a list",
+  "names": ["foo"],
+  "mappings": "AAAAA"
+}

--- a/resources/sources-content-not-a-list-2.js
+++ b/resources/sources-content-not-a-list-2.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=sources-content-not-a-list-2.js.map

--- a/resources/sources-content-not-a-list-2.js.map
+++ b/resources/sources-content-not-a-list-2.js.map
@@ -1,0 +1,7 @@
+{
+  "version" : 3,
+  "sources": ["first.js"],
+  "sourcesContent": { "foobar baz": 3 },
+  "names": ["foo"],
+  "mappings": "AAAAA"
+}

--- a/resources/sources-content-not-string-or-null.js
+++ b/resources/sources-content-not-string-or-null.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=sources-content-not-string-or-null.js.map

--- a/resources/sources-content-not-string-or-null.js.map
+++ b/resources/sources-content-not-string-or-null.js.map
@@ -1,0 +1,7 @@
+{
+  "version" : 3,
+  "sources": ["1.js", "2.js", "3.js", "4.js", "5.js"],
+  "sourcesContent": [3, {}, true, false, []],
+  "names": ["foo"],
+  "mappings": "AAAAA"
+}

--- a/source-map-spec-tests.json
+++ b/source-map-spec-tests.json
@@ -43,6 +43,13 @@
       "sourceMapIsValid": false
     },
     {
+      "name": "mappingsMissing",
+      "description": "Test a source map that is missing a necessary mappings field",
+      "baseFile": "mappings-missing.js",
+      "sourceMapFile": "mappings-missing.js.map",
+      "sourceMapIsValid": false
+    },
+    {
       "name": "sourcesMissing",
       "description": "Test a source map that is missing a necessary sources field",
       "baseFile": "sources-missing.js",
@@ -68,6 +75,34 @@
       "description": "Test a source map with a sources list that has non-string and non-null items",
       "baseFile": "sources-not-string-or-null.js",
       "sourceMapFile": "sources-not-string-or-null.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "sourcesContentMissing",
+      "description": "Test a source map that is missing an optional sourcesContent field",
+      "baseFile": "sources-content-missing.js",
+      "sourceMapFile": "sources-content-missing.js.map",
+      "sourceMapIsValid": true
+    },
+    {
+      "name": "sourcesContentNotAList1",
+      "description": "Test a source map with a sourcesContent field that is not a valid list (string)",
+      "baseFile": "sources-content-not-a-list-1.js",
+      "sourceMapFile": "sources-content-not-a-list-1.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "sourcesContentNotAList2",
+      "description": "Test a source map with a sourcesContent field that is not a valid list (object)",
+      "baseFile": "sources-content-not-a-list-2.js",
+      "sourceMapFile": "sources-content-not-a-list-2.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "sourcesContentNotStringOrNull",
+      "description": "Test a source map with a sourcesContent list that has non-string and non-null items",
+      "baseFile": "sources-not-string-or-null.js",
+      "sourceMapFile": "sources-content-not-string-or-null.js.map",
       "sourceMapIsValid": false
     },
     {


### PR DESCRIPTION
I've been going through the [spec test coverage](https://github.com/tc39/source-map-tests/wiki/Core-Spec-Test-Coverage) wiki page and double checking our test coverage by specifying the test case that covers each item.

In the process, a few cases turned out to be missing. These test cases are fairly simple and straightforward validity checking cases. I've tested them with the source map validator.