### PR TITLE
Add sourcesContent field to some tests

### DIFF
--- a/resources/index-map-invalid-base-mappings.js.map
+++ b/resources/index-map-invalid-base-mappings.js.map
@@ -8,6 +8,7 @@
         "version": 3,
         "names": [],
         "sources": ["empty-original.js"],
+        "sourcesContnet": [""],
         "mappings": "AAAA"
       }
     }

--- a/resources/index-map-invalid-order.js.map
+++ b/resources/index-map-invalid-order.js.map
@@ -6,7 +6,8 @@
       "map": {
         "version": 3,
         "names": [],
-        "sources": ["empty-original.js"],
+        "sources": ["empty-original-1.js"],
+        "sourcesContent": [""],
         "mappings": "AAAA"
       }
     },
@@ -15,7 +16,8 @@
       "map": {
         "version": 3,
         "names": [],
-        "sources": ["empty-original.js"],
+        "sources": ["empty-original-2.js"],
+        "sourcesContent": [""],
         "mappings": "AAAA"
       }
     }

--- a/resources/index-map-invalid-overlap.js.map
+++ b/resources/index-map-invalid-overlap.js.map
@@ -6,7 +6,8 @@
       "map": {
         "version": 3,
         "names": [],
-        "sources": ["empty-original.js"],
+        "sources": ["empty-original-1.js"],
+        "sourcesContent": [""],
         "mappings": "AAAA"
       }
     },
@@ -15,7 +16,8 @@
       "map": {
         "version": 3,
         "names": [],
-        "sources": ["empty-original.js"],
+        "sources": ["empty-original-2.js"],
+        "sourcesContent": [""],
         "mappings": "AAAA"
       }
     }

--- a/resources/index-map-missing-offset-column.js.map
+++ b/resources/index-map-missing-offset-column.js.map
@@ -7,6 +7,7 @@
         "version": 3,
         "names": [],
         "sources": ["empty-original.js"],
+        "sourcesContent": [""],
         "mappings": "AAAA"
       }
     }

--- a/resources/index-map-missing-offset-line.js.map
+++ b/resources/index-map-missing-offset-line.js.map
@@ -7,6 +7,7 @@
         "version": 3,
         "names": [],
         "sources": ["empty-original.js"],
+        "sourcesContent": [""],
         "mappings": "AAAA"
       }
     }

--- a/resources/index-map-missing-offset.js.map
+++ b/resources/index-map-missing-offset.js.map
@@ -6,6 +6,7 @@
         "version": 3,
         "names": [],
         "sources": ["empty-original.js"],
+        "sourcesContent": [""],
         "mappings": "AAAA"
       }
     }

--- a/resources/index-map-offset-column-wrong-type.js.map
+++ b/resources/index-map-offset-column-wrong-type.js.map
@@ -7,6 +7,7 @@
         "version": 3,
         "names": [],
         "sources": ["empty-original.js"],
+        "sourcesContent": [""],
         "mappings": "AAAA"
       }
     }

--- a/resources/index-map-offset-line-wrong-type.js.map
+++ b/resources/index-map-offset-line-wrong-type.js.map
@@ -7,6 +7,7 @@
         "version": 3,
         "names": [],
         "sources": ["empty-original.js"],
+        "sourcesContent": [""],
         "mappings": "AAAA"
       }
     }

--- a/resources/index-map-wrong-type-offset.js.map
+++ b/resources/index-map-wrong-type-offset.js.map
@@ -7,6 +7,7 @@
         "version": 3,
         "names": [],
         "sources": ["empty-original.js"],
+        "sourcesContent": [""],
         "mappings": "AAAA"
       }
     }

--- a/resources/invalid-mapping-not-a-string-1.js.map
+++ b/resources/invalid-mapping-not-a-string-1.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-not-a-string-1.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": 5
 }

--- a/resources/invalid-mapping-not-a-string-2.js.map
+++ b/resources/invalid-mapping-not-a-string-2.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-not-a-string-2.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": [1, 2, 3, 4]
 }

--- a/resources/invalid-mapping-segment-column-too-large.js.map
+++ b/resources/invalid-mapping-segment-column-too-large.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-column-too-large.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "ggggggE"
 }

--- a/resources/invalid-mapping-segment-name-index-out-of-bounds.js.map
+++ b/resources/invalid-mapping-segment-name-index-out-of-bounds.js.map
@@ -3,5 +3,6 @@
   "names": ["foo"],
   "file": "invalid-mapping-segment-name-index-out-of-bounds.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "AAAAC"
 }

--- a/resources/invalid-mapping-segment-name-index-too-large.js.map
+++ b/resources/invalid-mapping-segment-name-index-too-large.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-name-index-too-large.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "AAAAggggggE"
 }

--- a/resources/invalid-mapping-segment-negative-column.js.map
+++ b/resources/invalid-mapping-segment-negative-column.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-negative-column.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "F"
 }

--- a/resources/invalid-mapping-segment-negative-name-index.js.map
+++ b/resources/invalid-mapping-segment-negative-name-index.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-negative-name-index.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "AAAAF"
 }

--- a/resources/invalid-mapping-segment-negative-original-column.js.map
+++ b/resources/invalid-mapping-segment-negative-original-column.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-negative-original-column.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "AAAF"
 }

--- a/resources/invalid-mapping-segment-negative-original-line.js.map
+++ b/resources/invalid-mapping-segment-negative-original-line.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-negative-original-line.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "AAFA"
 }

--- a/resources/invalid-mapping-segment-negative-source-index.js.map
+++ b/resources/invalid-mapping-segment-negative-source-index.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-negative-source-index.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "AFAA"
 }

--- a/resources/invalid-mapping-segment-original-column-too-large.js.map
+++ b/resources/invalid-mapping-segment-original-column-too-large.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-original-column-too-large.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "AAAggggggE"
 }

--- a/resources/invalid-mapping-segment-original-line-too-large.js.map
+++ b/resources/invalid-mapping-segment-original-line-too-large.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-original-line-too-large.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "AAggggggEA"
 }

--- a/resources/invalid-mapping-segment-source-index-out-of-bounds.js.map
+++ b/resources/invalid-mapping-segment-source-index-out-of-bounds.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-source-index-out-of-bounds.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "ACAA"
 }

--- a/resources/invalid-mapping-segment-source-index-too-large.js.map
+++ b/resources/invalid-mapping-segment-source-index-too-large.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-source-index-too-large.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "AggggggEAA"
 }

--- a/resources/invalid-mapping-segment-with-zero-fields.js.map
+++ b/resources/invalid-mapping-segment-with-zero-fields.js.map
@@ -3,5 +3,6 @@
   "names": [],
   "file": "invalid-mapping-segment-with-zero-fields.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": ",,,,"
 }

--- a/resources/valid-mapping-boundary-values.js.map
+++ b/resources/valid-mapping-boundary-values.js.map
@@ -3,5 +3,6 @@
   "names": ["foo"],
   "file": "valid-mapping-boundary-values.js",
   "sources": ["empty-original.js"],
+  "sourcesContent": [""],
   "mappings": "+/////DA+/////D+/////DA"
 }


### PR DESCRIPTION
Some tests used a sources entry but without a sourcesContent, which could result in spurious test failures depending on the test setup (e.g., the source map validator) since the intent wasn't to test anything about sources in these tests.

This PR adds some trivial sourcesContent fields for these.