### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Source Map Tests
 
-This repository holds testing discussions and tests for the the Source Map debugging format. Specifically, we're looking to encourage discussion around:
+This repository holds discussions on testing and tests for the Source Map debugging format. Specifically, we're looking to encourage discussion around:
 
 - Manual and automated testing strategies for Source Maps
-- Gathering a list of Soure Map generators and consumers
+- Gathering a list of Source Map generators and consumers
 - General discussion around deviations between source maps
 
 Open discussion happens in the [GitHub issues](https://github.com/source-map/source-map-tests/issues).


### PR DESCRIPTION
Fix double "the" and "Soure map"