### PR TITLE
Add initial range mapping proposal tests

### DIFF
--- a/range-mappings-proposal-tests.json
+++ b/range-mappings-proposal-tests.json
@@ -1,0 +1,142 @@
+{
+  "resourceBasePath": "proposals/range-mappings",
+  "tests": [
+    {
+      "name": "rangeMappingsWrongType1",
+      "description": "Test an invalid source map with a malformed rangeMappings field",
+      "baseFile": "wrong-type-1.js",
+      "sourceMapFile": "wrong-type-1.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "rangeMappingsWrongType2",
+      "description": "Test an invalid source map with a malformed rangeMappings field",
+      "baseFile": "wrong-type-2.js",
+      "sourceMapFile": "wrong-type-2.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "rangeMappingsWrongType3",
+      "description": "Test an invalid source map with a malformed rangeMappings field",
+      "baseFile": "wrong-type-3.js",
+      "sourceMapFile": "wrong-type-3.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "rangeMappingsInvalidBase64Char1",
+      "description": "Test an invalid range mapping with an invalid base64 character",
+      "baseFile": "invalid-base64-char-1.js",
+      "sourceMapFile": "invalid-base64-char-1.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "rangeMappingsInvalidBase64Char2",
+      "description": "Test an invalid range mapping with an invalid base64 character",
+      "baseFile": "invalid-base64-char-2.js",
+      "sourceMapFile": "invalid-base64-char-2.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "rangeMappingsOutOfRange",
+      "description": "Test an invalid range mapping which is outside the mappings length",
+      "baseFile": "out-of-range.js",
+      "sourceMapFile": "out-of-range.js.map",
+      "sourceMapIsValid": false
+    },
+    {
+      "name": "rangeMappingsEmpty",
+      "description": "Test a trivial range mapping that is the empty string",
+      "baseFile": "empty-string.js",
+      "sourceMapFile": "empty-string.js.map",
+      "sourceMapIsValid": true
+    },
+    {
+      "name": "rangeMappingsNonFullLineCoverage",
+      "description": "Test a non-empty range mapping where not all lines in the generated source are covered",
+      "baseFile": "non-full-line-coverage.js",
+      "sourceMapFile": "non-full-line-coverage.js.map",
+      "sourceMapIsValid": true
+    },
+    {
+      "name": "rangeMappingsSimple",
+      "description": "Test a simple, single-entry rangeMappings",
+      "baseFile": "simple.js",
+      "sourceMapFile": "simple.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 1,
+          "generatedColumn": 1,
+          "originalSource": "simple-original.js",
+          "originalLine": 0,
+          "originalColumn": 0,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 1,
+          "generatedColumn": 2,
+          "originalSource": "simple-original.js",
+          "originalLine": 0,
+          "originalColumn": 1,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 1,
+          "generatedColumn": 3,
+          "originalSource": "simple-original.js",
+          "originalLine": 0,
+          "originalColumn": 2,
+          "mappedName": null
+        }
+      ]
+    },
+    {
+      "name": "rangeMappingsNewline",
+      "description": "Test rangeMappings entry continues through newlines",
+      "baseFile": "newline-semantics.js",
+      "sourceMapFile": "newline-semantics.js.map",
+      "sourceMapIsValid": true,
+      "testActions": [
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 1,
+          "originalSource": "newline-semantics-original.js",
+          "originalLine": 0,
+          "originalColumn": 0,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 0,
+          "generatedColumn": 7,
+          "originalSource": "newline-semantics-original.js",
+          "originalLine": 0,
+          "originalColumn": 6,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 1,
+          "generatedColumn": 0,
+          "originalSource": "newline-semantics-original.js",
+          "originalLine": 0,
+          "originalColumn": 7,
+          "mappedName": null
+        },
+        {
+          "actionType": "checkMapping",
+          "generatedLine": 1,
+          "generatedColumn": 5,
+          "originalSource": "newline-semantics-original.js",
+          "originalLine": 0,
+          "originalColumn": 12,
+          "mappedName": null
+        }
+      ]
+    }
+  ]
+}

--- a/resources/proposals/range-mappings/empty-string.js
+++ b/resources/proposals/range-mappings/empty-string.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=empty-string.js.map

--- a/resources/proposals/range-mappings/empty-string.js.map
+++ b/resources/proposals/range-mappings/empty-string.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "empty-string.js",
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "mappings": "",
+  "rangeMappings": ""
+}

--- a/resources/proposals/range-mappings/invalid-base64-char-1.js
+++ b/resources/proposals/range-mappings/invalid-base64-char-1.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=invalid-base64-char-1.js.map

--- a/resources/proposals/range-mappings/invalid-base64-char-1.js.map
+++ b/resources/proposals/range-mappings/invalid-base64-char-1.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "invalid-base64-char-1.js",
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "mappings": "",
+  "rangeMappings": "AB%"
+}

--- a/resources/proposals/range-mappings/invalid-base64-char-2.js
+++ b/resources/proposals/range-mappings/invalid-base64-char-2.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=invalid-base64-char-2.js.map

--- a/resources/proposals/range-mappings/invalid-base64-char-2.js.map
+++ b/resources/proposals/range-mappings/invalid-base64-char-2.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "invalid-base64-char-2.js",
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "mappings": "",
+  "rangeMappings": "ab="
+}

--- a/resources/proposals/range-mappings/newline-semantics.js
+++ b/resources/proposals/range-mappings/newline-semantics.js
@@ -1,0 +1,3 @@
+ "Hello 
+world"
+//# sourceMappingURL=newline-semantics.js.map

--- a/resources/proposals/range-mappings/newline-semantics.js.map
+++ b/resources/proposals/range-mappings/newline-semantics.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "empty-string.js",
+  "sources": ["newline-semantics-original.js"],
+  "sourcesContent": ["\"Hello World\""],
+  "mappings": "CAAA;A",
+  "rangeMappings": "B;"
+}

--- a/resources/proposals/range-mappings/non-full-line-coverage.js
+++ b/resources/proposals/range-mappings/non-full-line-coverage.js
@@ -1,0 +1,3 @@
+  
+ "Hello world"
+//# sourceMappingURL=non-full-line-coverage.js.map

--- a/resources/proposals/range-mappings/non-full-line-coverage.js.map
+++ b/resources/proposals/range-mappings/non-full-line-coverage.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "empty-string.js",
+  "sources": ["simple-original.js"],
+  "sourcesContent": ["\"Hello World\""],
+  "mappings": ";CAAA;A",
+  "rangeMappings": ";B"
+}

--- a/resources/proposals/range-mappings/out-of-range.js
+++ b/resources/proposals/range-mappings/out-of-range.js
@@ -1,0 +1,2 @@
+"foo"
+//# sourceMappingURL=out-of-range.js.map

--- a/resources/proposals/range-mappings/out-of-range.js.map
+++ b/resources/proposals/range-mappings/out-of-range.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "out-of-range.js",
+  "sources": ["foo.js"],
+  "sourcesContent": ["\"foo\""],
+  "mappings": "AAA",
+  "rangeMappings": "+"
+}

--- a/resources/proposals/range-mappings/simple.js
+++ b/resources/proposals/range-mappings/simple.js
@@ -1,0 +1,3 @@
+  
+ "Hello world"
+//# sourceMappingURL=empty-string.js.map

--- a/resources/proposals/range-mappings/simple.js.map
+++ b/resources/proposals/range-mappings/simple.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "empty-string.js",
+  "sources": ["simple-original.js"],
+  "sourcesContent": ["\"Hello World\""],
+  "mappings": ";CAAA;A",
+  "rangeMappings": ";B;"
+}

--- a/resources/proposals/range-mappings/wrong-type-1.js
+++ b/resources/proposals/range-mappings/wrong-type-1.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=wrong-type-1.js.map

--- a/resources/proposals/range-mappings/wrong-type-1.js.map
+++ b/resources/proposals/range-mappings/wrong-type-1.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "wrong-type-1.js",
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "mappings": "",
+  "rangeMappings": 3
+}

--- a/resources/proposals/range-mappings/wrong-type-2.js
+++ b/resources/proposals/range-mappings/wrong-type-2.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=wrong-type-2.js.map

--- a/resources/proposals/range-mappings/wrong-type-2.js.map
+++ b/resources/proposals/range-mappings/wrong-type-2.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "wrong-type-2.js",
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "mappings": "",
+  "rangeMappings": { x: "foo" }
+}

--- a/resources/proposals/range-mappings/wrong-type-3.js
+++ b/resources/proposals/range-mappings/wrong-type-3.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=wrong-type-3.js.map

--- a/resources/proposals/range-mappings/wrong-type-3.js.map
+++ b/resources/proposals/range-mappings/wrong-type-3.js.map
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "names": [],
+  "file": "wrong-type-3.js",
+  "sources": ["empty-original.js"],
+  "sourcesContent": [""],
+  "mappings": "",
+  "rangeMappings": ["foo"]
+}


### PR DESCRIPTION
This starts a test suite for the range mappings proposal, with the same test format as standard source map tests.

More tests, especially for more complex mapping situations, would be useful in the future but this should at least cover basic encoding validation for the `rangeMappings` field.