### PR TITLE
Update invalid baseFile field for test case

### DIFF
--- a/source-map-spec-tests.json
+++ b/source-map-spec-tests.json
@@ -101,7 +101,7 @@
     {
       "name": "sourcesContentNotStringOrNull",
       "description": "Test a source map with a sourcesContent list that has non-string and non-null items",
-      "baseFile": "sources-not-string-or-null.js",
+      "baseFile": "sources-content-not-string-or-null.js",
       "sourceMapFile": "sources-content-not-string-or-null.js.map",
       "sourceMapIsValid": false
     },


### PR DESCRIPTION
Replace test case `sourcesContentNotStringOrNull`'s baseFile field with the correct file `sources-content-not-string-or-null.js`.

The `sourcesContentNotStringOrNull` test case currently references a baseFile named `sources-not-string-or-null.js`. This is incorrect, and is the baseFile for the `sourcesNotStringOrNull` test.

The correct baseFile for this test should be "sources-content-not-string-or-null.js".

I have reviewed all other test cases and found no similar instances of this error.