### PR TITLE
Scopes: Add some decoding tests for 'original scope records'

### DIFF
--- a/decoding/scopes/close-start-end-position-scopes.map
+++ b/decoding/scopes/close-start-end-position-scopes.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "close-start-end-position-scopes.js",
+  "sources": [
+    "original_0.js"
+  ],
+  "mappings": "",
+  "names": [],
+  "scopes": "BAAA,BAAA,CAB,BAAA,CAB,BAAB,CAC,CBA"
+}

--- a/decoding/scopes/close-start-end-position-scopes.map.golden
+++ b/decoding/scopes/close-start-end-position-scopes.map.golden
@@ -1,0 +1,73 @@
+{
+  "file": "close-start-end-position-scopes.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 0
+        },
+        "name": null,
+        "kind": null,
+        "isStackFrame": false,
+        "variables": [],
+        "children": [
+          {
+            "start": {
+              "line": 0,
+              "column": 0
+            },
+            "end": {
+              "line": 0,
+              "column": 1
+            },
+            "name": null,
+            "kind": null,
+            "isStackFrame": false,
+            "variables": [],
+            "children": []
+          },
+          {
+            "start": {
+              "line": 0,
+              "column": 1
+            },
+            "end": {
+              "line": 0,
+              "column": 2
+            },
+            "name": null,
+            "kind": null,
+            "isStackFrame": false,
+            "variables": [],
+            "children": []
+          },
+          {
+            "start": {
+              "line": 0,
+              "column": 3
+            },
+            "end": {
+              "line": 0,
+              "column": 5
+            },
+            "name": null,
+            "kind": null,
+            "isStackFrame": false,
+            "variables": [],
+            "children": []
+          }
+        ]
+      }
+    }
+  ],
+  "ranges": []
+}

--- a/decoding/scopes/empty-scopes-field.map
+++ b/decoding/scopes/empty-scopes-field.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "file": "empty-scopes-field.js",
+  "sources": [],
+  "mappings": "",
+  "names": [],
+  "scopes": ""
+}

--- a/decoding/scopes/empty-scopes-field.map.golden
+++ b/decoding/scopes/empty-scopes-field.map.golden
@@ -1,0 +1,6 @@
+{
+  "file": "empty-scopes-field.js",
+  "mappings": [],
+  "sources": [],
+  "ranges": []
+}

--- a/decoding/scopes/multiple-root-original-scopes-with-nil.map
+++ b/decoding/scopes/multiple-root-original-scopes-with-nil.map
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "file": "multiple-root-original-scopes-with-nil.js",
+  "sources": [
+    "original_0.js",
+    "original_1.js",
+    "original_2.js"
+  ],
+  "mappings": "",
+  "names": [
+    "global"
+  ],
+  "scopes": "BCAAA,CKA,A,BCAAA,CKA"
+}

--- a/decoding/scopes/multiple-root-original-scopes-with-nil.map.golden
+++ b/decoding/scopes/multiple-root-original-scopes-with-nil.map.golden
@@ -1,0 +1,53 @@
+{
+  "file": "multiple-root-original-scopes-with-nil.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        },
+        "name": null,
+        "kind": "global",
+        "isStackFrame": false,
+        "variables": [],
+        "children": []
+      }
+    },
+    {
+      "url": "original_1.js",
+      "content": null,
+      "ignored": false,
+      "scope": null
+    },
+    {
+      "url": "original_2.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        },
+        "name": null,
+        "kind": "global",
+        "isStackFrame": false,
+        "variables": [],
+        "children": []
+      }
+    }
+  ],
+  "ranges": []
+}

--- a/decoding/scopes/nested-scopes.map
+++ b/decoding/scopes/nested-scopes.map
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "file": "nested-scopes.js",
+  "sources": [
+    "original_0.js"
+  ],
+  "mappings": "",
+  "names": [
+    "originalFunctionFoo",
+    "innerOriginalFunction",
+    "block"
+  ],
+  "scopes": "BAAA,BFKAA,BFFCC,BCFEE,CFE,CBC,CBA,CBA"
+}

--- a/decoding/scopes/nested-scopes.map.golden
+++ b/decoding/scopes/nested-scopes.map.golden
@@ -1,0 +1,75 @@
+{
+  "file": "nested-scopes.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 28,
+          "column": 0
+        },
+        "name": null,
+        "kind": null,
+        "isStackFrame": false,
+        "variables": [],
+        "children": [
+          {
+            "start": {
+              "line": 10,
+              "column": 0
+            },
+            "end": {
+              "line": 27,
+              "column": 0
+            },
+            "name": "originalFunctionFoo",
+            "kind": null,
+            "isStackFrame": true,
+            "variables": [],
+            "children": [
+              {
+                "start": {
+                  "line": 15,
+                  "column": 2
+                },
+                "end": {
+                  "line": 26,
+                  "column": 2
+                },
+                "name": "innerOriginalFunction",
+                "kind": null,
+                "isStackFrame": true,
+                "variables": [],
+                "children": [
+                  {
+                    "start": {
+                      "line": 20,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 25,
+                      "column": 4
+                    },
+                    "name": null,
+                    "kind": "block",
+                    "isStackFrame": false,
+                    "variables": [],
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "ranges": []
+}

--- a/decoding/scopes/nil-scopes.map
+++ b/decoding/scopes/nil-scopes.map
@@ -1,0 +1,13 @@
+{
+  "version": 3,
+  "file": "nil-scopes.js",
+  "sources": [
+    "original_0.js",
+    "original_1.js",
+    "original_2.js",
+    "original_3.js"
+  ],
+  "mappings": "",
+  "names": [],
+  "scopes": "A,A,A,A"
+}

--- a/decoding/scopes/nil-scopes.map.golden
+++ b/decoding/scopes/nil-scopes.map.golden
@@ -1,0 +1,31 @@
+{
+  "file": "nil-scopes.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": null
+    },
+    {
+      "url": "original_1.js",
+      "content": null,
+      "ignored": false,
+      "scope": null
+    },
+    {
+      "url": "original_2.js",
+      "content": null,
+      "ignored": false,
+      "scope": null
+    },
+    {
+      "url": "original_3.js",
+      "content": null,
+      "ignored": false,
+      "scope": null
+    }
+  ],
+  "ranges": []
+}

--- a/decoding/scopes/scope-variables.map
+++ b/decoding/scopes/scope-variables.map
@@ -1,0 +1,23 @@
+{
+  "version": 3,
+  "file": "scope-variables.js",
+  "sources": [
+    "original_0.js"
+  ],
+  "mappings": "",
+  "names": [
+    "global",
+    "GLOBAL_CONSTANT1",
+    "GLOBAL_CONSTANT2",
+    "toplevelFunction1",
+    "function",
+    "functionScopedVariable1",
+    "functionScopedVariable2",
+    "functionScopedVariable3",
+    "toplevelFunction2",
+    "block",
+    "blockScopedVariable1",
+    "blockScopedVariable2"
+  ],
+  "scopes": "BCAAA,DCC,BHKFGI,DGCC,CJB,BHGFKA,DF,BCBIK,DKC,CDF,CBB,CBA"
+}

--- a/decoding/scopes/scope-variables.map.golden
+++ b/decoding/scopes/scope-variables.map.golden
@@ -1,0 +1,86 @@
+{
+  "file": "scope-variables.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 31,
+          "column": 0
+        },
+        "name": null,
+        "kind": "global",
+        "isStackFrame": false,
+        "variables": [
+          "GLOBAL_CONSTANT1",
+          "GLOBAL_CONSTANT2"
+        ],
+        "children": [
+          {
+            "start": {
+              "line": 10,
+              "column": 5
+            },
+            "end": {
+              "line": 19,
+              "column": 1
+            },
+            "name": "toplevelFunction1",
+            "kind": "function",
+            "isStackFrame": true,
+            "variables": [
+              "functionScopedVariable1",
+              "functionScopedVariable2",
+              "functionScopedVariable3"
+            ],
+            "children": []
+          },
+          {
+            "start": {
+              "line": 25,
+              "column": 5
+            },
+            "end": {
+              "line": 30,
+              "column": 1
+            },
+            "name": "toplevelFunction2",
+            "kind": "function",
+            "isStackFrame": true,
+            "variables": [
+              "functionScopedVariable1"
+            ],
+            "children": [
+              {
+                "start": {
+                  "line": 26,
+                  "column": 8
+                },
+                "end": {
+                  "line": 29,
+                  "column": 5
+                },
+                "name": null,
+                "kind": "block",
+                "isStackFrame": false,
+                "variables": [
+                  "blockScopedVariable1",
+                  "blockScopedVariable2"
+                ],
+                "children": []
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "ranges": []
+}

--- a/decoding/scopes/sibling-scopes.map
+++ b/decoding/scopes/sibling-scopes.map
@@ -1,0 +1,16 @@
+{
+  "version": 3,
+  "file": "sibling-scopes.js",
+  "sources": [
+    "original_0.js"
+  ],
+  "mappings": "",
+  "names": [
+    "toplevelFunction1",
+    "function",
+    "toplevelFunction2",
+    "toplevelFunction3",
+    "toplevelFunction4"
+  ],
+  "scopes": "BAAA,BHKFAC,CIB,BHCFEA,CIB,BHCFCA,CIB,BHCFCA,CIB,CCA"
+}

--- a/decoding/scopes/sibling-scopes.map.golden
+++ b/decoding/scopes/sibling-scopes.map.golden
@@ -1,0 +1,88 @@
+{
+  "file": "sibling-scopes.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 50,
+          "column": 0
+        },
+        "name": null,
+        "kind": null,
+        "isStackFrame": false,
+        "variables": [],
+        "children": [
+          {
+            "start": {
+              "line": 10,
+              "column": 5
+            },
+            "end": {
+              "line": 18,
+              "column": 1
+            },
+            "name": "toplevelFunction1",
+            "kind": "function",
+            "isStackFrame": true,
+            "variables": [],
+            "children": []
+          },
+          {
+            "start": {
+              "line": 20,
+              "column": 5
+            },
+            "end": {
+              "line": 28,
+              "column": 1
+            },
+            "name": "toplevelFunction2",
+            "kind": "function",
+            "isStackFrame": true,
+            "variables": [],
+            "children": []
+          },
+          {
+            "start": {
+              "line": 30,
+              "column": 5
+            },
+            "end": {
+              "line": 38,
+              "column": 1
+            },
+            "name": "toplevelFunction3",
+            "kind": "function",
+            "isStackFrame": true,
+            "variables": [],
+            "children": []
+          },
+          {
+            "start": {
+              "line": 40,
+              "column": 5
+            },
+            "end": {
+              "line": 48,
+              "column": 1
+            },
+            "name": "toplevelFunction4",
+            "kind": "function",
+            "isStackFrame": true,
+            "variables": [],
+            "children": []
+          }
+        ]
+      }
+    }
+  ],
+  "ranges": []
+}


### PR DESCRIPTION
This PR adds some basic "success" tests for original scope records. Some simple variants about nested and sibling scopes. Both with/without variables and with/without name or kind.

Tests for generated ranges, combination of ranges and scopes and "failure" tests will come in separate PRs.