### PR TITLE
scopes: add basic decoding tests for generated ranges

### DIFF
--- a/decoding/scopes/README.md
+++ b/decoding/scopes/README.md
@@ -1,0 +1,18 @@
+## Test cases
+
+- **empty-scopes-field**: Empty original scopes field
+- **nil-scopes**: Multiple null original scopes
+- **close-start-end-position-scopes**: Scopes with very close start and end
+  positions
+- **single-root-original-scope**: A single global root original scope
+- **nested-scopes**: Nested original scopes representing functions and blocks
+- **sibling-scopes**: Multiple sibling top-level functions
+- **scope-variables**: Scopes containing variable declarations
+- **multiple-root-original-scopes-with-nil**: Multiple global root scopes with a
+  null scope in between
+- **sibling-ranges**: Multiple sibling root ranges
+- **nested-ranges**: A root range with a nested function range
+- **range-values**: A root range with a non-function range with bindings
+- **sub-range-values**: A root range with sub-range bindings
+- **range-call-site**: A function inlined into the root scope
+- **hidden-ranges**: A function range corresponding to an original block scope

--- a/decoding/scopes/hidden-ranges.map
+++ b/decoding/scopes/hidden-ranges.map
@@ -1,0 +1,13 @@
+{
+  "version": 3,
+  "file": "hidden-ranges.js",
+  "sources": [
+    "original_0.js"
+  ],
+  "mappings": "",
+  "names": [
+    "global",
+    "block"
+  ],
+  "scopes": "BCAAA,BCBAC,CEA,CFA,ECAA,EPBAC,FEA,FFA"
+}

--- a/decoding/scopes/hidden-ranges.map.golden
+++ b/decoding/scopes/hidden-ranges.map.golden
@@ -1,0 +1,75 @@
+{
+  "file": "hidden-ranges.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        },
+        "name": null,
+        "kind": "global",
+        "isStackFrame": false,
+        "variables": [],
+        "children": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 5,
+              "column": 0
+            },
+            "name": null,
+            "kind": "block",
+            "isStackFrame": false,
+            "variables": [],
+            "children": []
+          }
+        ]
+      }
+    }
+  ],
+  "ranges": [
+    {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 10,
+        "column": 0
+      },
+      "definitionIndex": 0,
+      "stackFrameType": "none",
+      "callSite": null,
+      "bindings": [],
+      "children": [
+        {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 0
+          },
+          "definitionIndex": 1,
+          "stackFrameType": "hidden",
+          "callSite": null,
+          "bindings": [],
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/decoding/scopes/nested-ranges.map
+++ b/decoding/scopes/nested-ranges.map
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "file": "nested-ranges.js",
+  "sources": [
+    "original_0.js"
+  ],
+  "mappings": "",
+  "names": [
+    "global",
+    "foo",
+    "function"
+  ],
+  "scopes": "BCAAA,BHBACE,CEA,CFA,ECAA,EGCC,FC,FG"
+}

--- a/decoding/scopes/nested-ranges.map.golden
+++ b/decoding/scopes/nested-ranges.map.golden
@@ -1,0 +1,75 @@
+{
+  "file": "nested-ranges.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        },
+        "name": null,
+        "kind": "global",
+        "isStackFrame": false,
+        "variables": [],
+        "children": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 5,
+              "column": 0
+            },
+            "name": "foo",
+            "kind": "function",
+            "isStackFrame": true,
+            "variables": [],
+            "children": []
+          }
+        ]
+      }
+    }
+  ],
+  "ranges": [
+    {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 10
+      },
+      "definitionIndex": 0,
+      "stackFrameType": "none",
+      "callSite": null,
+      "bindings": [],
+      "children": [
+        {
+          "start": {
+            "line": 0,
+            "column": 2
+          },
+          "end": {
+            "line": 0,
+            "column": 4
+          },
+          "definitionIndex": 1,
+          "stackFrameType": "original",
+          "callSite": null,
+          "bindings": [],
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/decoding/scopes/range-call-site.map
+++ b/decoding/scopes/range-call-site.map
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "file": "range-call-site.js",
+  "sources": [
+    "original_0.js"
+  ],
+  "mappings": "",
+  "names": [
+    "global",
+    "inlineMe",
+    "function"
+  ],
+  "scopes": "BCAAA,BHBACE,CEA,CFA,ECAA,EDBAC,IAGC,FK,FJA"
+}

--- a/decoding/scopes/range-call-site.map.golden
+++ b/decoding/scopes/range-call-site.map.golden
@@ -1,0 +1,79 @@
+{
+  "file": "range-call-site.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        },
+        "name": null,
+        "kind": "global",
+        "isStackFrame": false,
+        "variables": [],
+        "children": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 5,
+              "column": 0
+            },
+            "name": "inlineMe",
+            "kind": "function",
+            "isStackFrame": true,
+            "variables": [],
+            "children": []
+          }
+        ]
+      }
+    }
+  ],
+  "ranges": [
+    {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 10,
+        "column": 0
+      },
+      "definitionIndex": 0,
+      "stackFrameType": "none",
+      "callSite": null,
+      "bindings": [],
+      "children": [
+        {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 10
+          },
+          "definitionIndex": 1,
+          "stackFrameType": "none",
+          "callSite": {
+            "sourceIndex": 0,
+            "line": 6,
+            "column": 2
+          },
+          "bindings": [],
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/decoding/scopes/range-values.map
+++ b/decoding/scopes/range-values.map
@@ -1,0 +1,20 @@
+{
+  "version": 3,
+  "file": "range-values.js",
+  "sources": [
+    "original_0.js"
+  ],
+  "mappings": "",
+  "names": [
+    "global",
+    "x",
+    "y",
+    "z",
+    "block",
+    "a",
+    "x_val",
+    "z_val",
+    "a_val"
+  ],
+  "scopes": "BCAAA,DCCC,BCBAI,DE,CEA,CFA,ECAA,GHAI,ECCC,GJ,FC,FG"
+}

--- a/decoding/scopes/range-values.map.golden
+++ b/decoding/scopes/range-values.map.golden
@@ -1,0 +1,119 @@
+{
+  "file": "range-values.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        },
+        "name": null,
+        "kind": "global",
+        "isStackFrame": false,
+        "variables": [
+          "x",
+          "y",
+          "z"
+        ],
+        "children": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 5,
+              "column": 0
+            },
+            "name": null,
+            "kind": "block",
+            "isStackFrame": false,
+            "variables": [
+              "a"
+            ],
+            "children": []
+          }
+        ]
+      }
+    }
+  ],
+  "ranges": [
+    {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 10
+      },
+      "definitionIndex": 0,
+      "stackFrameType": "none",
+      "callSite": null,
+      "bindings": [
+        [
+          {
+            "binding": "x_val",
+            "from": {
+              "line": 0,
+              "column": 0
+            }
+          }
+        ],
+        [
+          {
+            "binding": null,
+            "from": {
+              "line": 0,
+              "column": 0
+            }
+          }
+        ],
+        [
+          {
+            "binding": "z_val",
+            "from": {
+              "line": 0,
+              "column": 0
+            }
+          }
+        ]
+      ],
+      "children": [
+        {
+          "start": {
+            "line": 0,
+            "column": 2
+          },
+          "end": {
+            "line": 0,
+            "column": 4
+          },
+          "definitionIndex": 1,
+          "stackFrameType": "none",
+          "callSite": null,
+          "bindings": [
+            [
+              {
+                "binding": "a_val",
+                "from": {
+                  "line": 0,
+                  "column": 2
+                }
+              }
+            ]
+          ],
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/decoding/scopes/sibling-ranges.map
+++ b/decoding/scopes/sibling-ranges.map
@@ -1,0 +1,13 @@
+{
+  "version": 3,
+  "file": "sibling-ranges.js",
+  "sources": [
+    "original_0.js",
+    "original_1.js"
+  ],
+  "mappings": "",
+  "names": [
+    "global"
+  ],
+  "scopes": "BCAAA,CKA,BCKAA,CKA,ECAA,FK,EDKAC,FK,EBKA,FK"
+}

--- a/decoding/scopes/sibling-ranges.map.golden
+++ b/decoding/scopes/sibling-ranges.map.golden
@@ -1,0 +1,93 @@
+{
+  "file": "sibling-ranges.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        },
+        "name": null,
+        "kind": "global",
+        "isStackFrame": false,
+        "variables": [],
+        "children": []
+      }
+    },
+    {
+      "url": "original_1.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 10,
+          "column": 0
+        },
+        "end": {
+          "line": 20,
+          "column": 0
+        },
+        "name": null,
+        "kind": "global",
+        "isStackFrame": false,
+        "variables": [],
+        "children": []
+      }
+    }
+  ],
+  "ranges": [
+    {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 10
+      },
+      "definitionIndex": 0,
+      "stackFrameType": "none",
+      "callSite": null,
+      "bindings": [],
+      "children": []
+    },
+    {
+      "start": {
+        "line": 10,
+        "column": 0
+      },
+      "end": {
+        "line": 10,
+        "column": 10
+      },
+      "definitionIndex": 1,
+      "stackFrameType": "none",
+      "callSite": null,
+      "bindings": [],
+      "children": []
+    },
+    {
+      "start": {
+        "line": 20,
+        "column": 0
+      },
+      "end": {
+        "line": 20,
+        "column": 10
+      },
+      "definitionIndex": null,
+      "stackFrameType": "none",
+      "callSite": null,
+      "bindings": [],
+      "children": []
+    }
+  ]
+}

--- a/decoding/scopes/sub-range-values.map
+++ b/decoding/scopes/sub-range-values.map
@@ -13,5 +13,5 @@
     "y_val",
     "x_sub_val2"
   ],
-  "scopes": "BCAAA,DCC,CKA,ECAA,GEF,HAAADGAD,FK"
+  "scopes": "BCAAA,DCC,CKA,ECAA,GEF,HAADAADG,FK"
 }

--- a/decoding/scopes/sub-range-values.map
+++ b/decoding/scopes/sub-range-values.map
@@ -1,0 +1,17 @@
+{
+  "version": 3,
+  "file": "sub-range-values.js",
+  "sources": [
+    "original_0.js"
+  ],
+  "mappings": "",
+  "names": [
+    "global",
+    "x",
+    "y",
+    "x_sub_val1",
+    "y_val",
+    "x_sub_val2"
+  ],
+  "scopes": "BCAAA,DCC,CKA,ECAA,GEF,HAAADGAD,FK"
+}

--- a/decoding/scopes/sub-range-values.map.golden
+++ b/decoding/scopes/sub-range-values.map.golden
@@ -1,0 +1,79 @@
+{
+  "file": "sub-range-values.js",
+  "mappings": [],
+  "sources": [
+    {
+      "url": "original_0.js",
+      "content": null,
+      "ignored": false,
+      "scope": {
+        "start": {
+          "line": 0,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 0
+        },
+        "name": null,
+        "kind": "global",
+        "isStackFrame": false,
+        "variables": [
+          "x",
+          "y"
+        ],
+        "children": []
+      }
+    }
+  ],
+  "ranges": [
+    {
+      "start": {
+        "line": 0,
+        "column": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 10
+      },
+      "definitionIndex": 0,
+      "stackFrameType": "none",
+      "callSite": null,
+      "bindings": [
+        [
+          {
+            "binding": "x_sub_val1",
+            "from": {
+              "line": 0,
+              "column": 0
+            }
+          },
+          {
+            "binding": null,
+            "from": {
+              "line": 0,
+              "column": 3
+            }
+          },
+          {
+            "binding": "x_sub_val2",
+            "from": {
+              "line": 0,
+              "column": 6
+            }
+          }
+        ],
+        [
+          {
+            "binding": "y_val",
+            "from": {
+              "line": 0,
+              "column": 0
+            }
+          }
+        ]
+      ],
+      "children": []
+    }
+  ]
+}


### PR DESCRIPTION
More "success" cases. I'll add various "error" cases in a follow-up.

Drive-by: Add a simple `README.md` to describe scope decoding test cases.